### PR TITLE
Add request logging middleware with request IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ Edita `.env` con las credenciales reales.
 - `make lint`: ejecuta `ruff`.
 - `make fmt`: formatea con `black` e `isort`.
 
+## Logs
+
+El middleware de la aplicación imprime un log JSON por cada request en `stdout` con los
+campos `time`, `level`, `request_id`, `method`, `path`, `status_code` y `latency_ms`.
+Puedes verlos ejecutando la API de manera interactiva:
+
+```bash
+make run
+```
+
+o siguiendo los logs del contenedor si usas Docker:
+
+```bash
+docker compose logs -f
+```
+
 ## Docker
 
 Construir y ejecutar la API:


### PR DESCRIPTION
## Summary
- replace the request middleware to generate a request ID per request and emit structured JSON logs to stdout
- ensure unexpected exceptions return a 500 response, add a request ID header, and include a truncated stack trace in the log entry
- document how to read the new JSON logs in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbfe1013548331b1f7f06d666f5ee2