### PR TITLE
Add JWT issuance utilities and dev token endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,26 @@ cp .env.example .env
 
 Edita `.env` con las credenciales reales.
 
+## Autenticación y tokens
+
+En entorno de desarrollo (`ENV=dev`) la API expone un endpoint auxiliar para
+generar un token JWT válido:
+
+```bash
+export ENV=dev  # o configúralo en tu archivo .env
+make run &      # arranca la API en otra terminal si lo prefieres
+
+curl http://127.0.0.1:8000/dev/token
+# {"token": "<jwt>"}
+```
+
+El token está firmado con `JWT_SECRET` y utiliza los valores `JWT_ISSUER` y
+`JWT_AUDIENCE` configurados en tu `.env`. Puedes reutilizarlo en las llamadas a
+los endpoints protegidos mediante el header `Authorization: Bearer <jwt>`.
+El ejemplo de cURL que sigue usa [`jq`](https://stedolan.github.io/jq/) para
+extraer el token de la respuesta JSON; si no lo tienes instalado, copia el valor
+manualmente.
+
 ## Comandos Make
 
 - `make install`: instala dependencias en el entorno activo.
@@ -57,8 +77,10 @@ La API quedará disponible en `http://localhost:8000`.
 
 ```bash
 # Clock-in
+TOKEN="$(curl -s http://localhost:8000/dev/token | jq -r .token)"
+
 curl -X POST http://localhost:8000/clock-in \
-  -H "Authorization: Bearer <token>" \
+  -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{
     "workOrderAssemblyId": 1,
@@ -69,7 +91,7 @@ curl -X POST http://localhost:8000/clock-in \
 
 # Clock-out
 curl -X POST http://localhost:8000/clock-out \
-  -H "Authorization: Bearer <token>" \
+  -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{
     "workOrderCollectionId": 123,

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 import traceback
 import uuid
@@ -14,6 +15,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse, Response
 
 from .routers import clock
+from .security import issue_token
 
 
 def _now_iso() -> str:
@@ -76,6 +78,15 @@ def create_app() -> FastAPI:
     application = FastAPI()
     application.add_middleware(RequestIdMiddleware)
     application.include_router(clock.router)
+
+    if os.getenv("ENV") == "dev":
+
+        @application.get("/dev/token")
+        def dev_token() -> dict[str, str]:
+            """Return a short-lived development token."""
+
+            return {"token": issue_token("dev-user")}
+
     return application
 
 


### PR DESCRIPTION
## Summary
- implement JWT helper for issuing tokens and validate bearer tokens via FastAPI dependency
- expose a development-only endpoint to issue a token
- document how to obtain and use tokens in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc0940630c8331954c07aed9601ff7