### PR TITLE
Add user status endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI, Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse, Response
 
-from .routers import clock
+from .routers import clock, user
 
 
 def _now_iso() -> str:
@@ -76,6 +76,7 @@ def create_app() -> FastAPI:
     application = FastAPI()
     application.add_middleware(RequestIdMiddleware)
     application.include_router(clock.router)
+    application.include_router(user.router)
 
     return application
 

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,5 +1,5 @@
 """Routers package."""
 
-from . import clock
+from . import clock, user
 
-__all__ = ["clock"]
+__all__ = ["clock", "user"]

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -1,0 +1,98 @@
+"""User related endpoints router."""
+
+from __future__ import annotations
+
+from contextlib import closing
+import logging
+from typing import Optional
+
+import pymssql
+from fastapi import APIRouter, HTTPException, status
+
+from ..db import get_conn
+from ..schemas import UserStatusResponse
+
+_logger = logging.getLogger(__name__)
+
+
+router = APIRouter(prefix="", tags=["user"])
+
+
+_USER_QUERY = """
+SELECT UserPK, FirstName, LastName
+FROM dbo.[User]
+WHERE UserPK = %s
+"""
+
+
+_ACTIVE_WORK_ORDER_QUERY = """
+SELECT TOP (1)
+    w.WorkOrderCollectionPK,
+    w.WorkOrderNumber,
+    w.WorkOrderAssemblyNumber,
+    w.TimeOn,
+    wo.PartNumber,
+    op.Code AS OperationCode,
+    op.Name AS OperationName
+FROM dbo.WorkOrderCollection AS w
+LEFT JOIN dbo.WorkOrder AS wo
+       ON wo.WorkOrderNumber = w.WorkOrderNumber
+LEFT JOIN dbo.WorkOrderAssembly AS wa
+       ON wa.WorkOrderFK = wo.WorkOrderPK
+      AND wa.SequenceNumber = w.WorkOrderAssemblyNumber
+LEFT JOIN dbo.Operation AS op
+       ON op.OperationPK = wa.OperationFK
+WHERE w.EmployeeFK = %s
+  AND w.TimeOff IS NULL
+  AND w.TimeOn IS NOT NULL
+ORDER BY w.TimeOn DESC
+"""
+
+
+def _safe_get(row: Optional[dict[str, object]], key: str) -> Optional[object]:
+    """Return row[key] if row exists, otherwise ``None``."""
+
+    if not row:
+        return None
+    return row.get(key)
+
+
+@router.get("/users/{user_id}", response_model=UserStatusResponse)
+def get_user_status(user_id: int) -> UserStatusResponse:
+    """Validate a user exists and return their active work order information."""
+
+    try:
+        with closing(get_conn()) as conn:
+            with conn.cursor(as_dict=True) as cursor:
+                cursor.execute(_USER_QUERY, (user_id,))
+                user_row = cursor.fetchone()
+
+                if not user_row:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail="USER_NOT_FOUND",
+                    )
+
+                cursor.execute(_ACTIVE_WORK_ORDER_QUERY, (user_id,))
+                work_order_row = cursor.fetchone()
+    except pymssql.Error as exc:  # pragma: no cover - requires live DB
+        _logger.exception("Database error while fetching user status")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="DB_ERROR",
+        ) from exc
+
+    return UserStatusResponse(
+        user_id=int(user_row["UserPK"]),
+        first_name=str(user_row.get("FirstName") or ""),
+        last_name=str(user_row.get("LastName") or ""),
+        work_order_collection_id=_safe_get(work_order_row, "WorkOrderCollectionPK"),
+        work_order_number=_safe_get(work_order_row, "WorkOrderNumber"),
+        work_order_assembly_number=_safe_get(
+            work_order_row, "WorkOrderAssemblyNumber"
+        ),
+        clock_in_time=_safe_get(work_order_row, "TimeOn"),
+        part_number=_safe_get(work_order_row, "PartNumber"),
+        operation_code=_safe_get(work_order_row, "OperationCode"),
+        operation_name=_safe_get(work_order_row, "OperationName"),
+    )

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -44,3 +44,24 @@ class ClockOutResponse(BaseModel):
     status: str
 
     model_config = {"populate_by_name": True}
+
+
+class UserStatusResponse(BaseModel):
+    user_id: int = Field(alias="userId")
+    first_name: str = Field(alias="firstName")
+    last_name: str = Field(alias="lastName")
+    work_order_collection_id: Optional[int] = Field(
+        default=None, alias="workOrderCollectionId"
+    )
+    work_order_number: Optional[str] = Field(
+        default=None, alias="workOrderNumber"
+    )
+    work_order_assembly_number: Optional[int] = Field(
+        default=None, alias="workOrderAssemblyNumber"
+    )
+    clock_in_time: Optional[datetime] = Field(default=None, alias="clockInTime")
+    part_number: Optional[str] = Field(default=None, alias="partNumber")
+    operation_code: Optional[str] = Field(default=None, alias="operationCode")
+    operation_name: Optional[str] = Field(default=None, alias="operationName")
+
+    model_config = {"populate_by_name": True}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -7,10 +7,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from app.routers import clock  # noqa: E402
+from app.routers import clock, user  # noqa: E402
 
 
-def test_clock_router_has_no_dependencies() -> None:
-    """Ensure the clock router does not enforce authentication."""
+def test_routers_have_no_dependencies() -> None:
+    """Ensure the routers do not enforce authentication."""
 
     assert clock.router.dependencies == []
+    assert user.router.dependencies == []


### PR DESCRIPTION
## Summary
- add a user router endpoint that validates the user and returns their active work order details
- register the new router with the application and expose a response schema for the returned data
- keep router dependency tests up to date for the new endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd7924b2708331ab2944c067e73ac0